### PR TITLE
Refector Python bot to Java

### DIFF
--- a/src/main/java/entities/Server.java
+++ b/src/main/java/entities/Server.java
@@ -7,7 +7,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * An object that provides Topic CRUD methods for a Guild.
+ * An object that provides methods to store Topic information into
+ * a Guild's role list.
  */
 public class Server {
     private final Guild guild;

--- a/src/main/java/entities/Server.java
+++ b/src/main/java/entities/Server.java
@@ -47,7 +47,7 @@ public class Server {
         guild.createRole()
                 .setName("Topic | " + topic.getName())
                 .setMentionable(true)
-                .complete();
+                .queue();
         topics.add(topic);
     }
 
@@ -57,7 +57,7 @@ public class Server {
      */
     public void deleteTopic(Topic topic) {
         guild.getRolesByName("Topic | " + topic.getName(), true)
-                .forEach((role -> role.delete().complete()));
+                .forEach((role -> role.delete().queue()));
         topics.remove(topic);
     }
 

--- a/src/main/java/entities/Server.java
+++ b/src/main/java/entities/Server.java
@@ -1,0 +1,71 @@
+package entities;
+
+import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.Role;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * An object that provides Topic CRUD methods for a Guild.
+ */
+public class Server {
+    private final Guild guild;
+    private final ArrayList<Topic> topics = new ArrayList<>();
+
+    public Server(Guild guild) {
+        this.guild = guild;
+    }
+
+    @Override
+    public int hashCode() {
+        return guild.getName().hashCode();
+    }
+
+    /**
+     * Constructs a Server object from a Guild's role list.
+     * @param guild The guild to build from
+     * @return A Server with all topics added
+     */
+    public static Server load(Guild guild) {
+        Server server = new Server(guild);
+        List<Role> roles = guild.getRoles();
+        for (Role role : roles) {
+            String name = role.getName();
+            if (name.startsWith("Topic | ")) {
+                server.topics.add(new Topic(name.substring(8)));
+            }
+        }
+        return server;
+    }
+
+    /**
+     * Creates a new Topic role in this server.
+     * @param topic The Topic to add
+     */
+    public void createTopic(Topic topic) {
+        guild.createRole()
+                .setName("Topic | " + topic.getName())
+                .setMentionable(true)
+                .complete();
+        topics.add(topic);
+    }
+
+    /**
+     * Deletes the Topic role from this server.
+     * @param topic The Topic to remove
+     */
+    public void deleteTopic(Topic topic) {
+        guild.getRolesByName("Topic | " + topic.getName(), true)
+                .forEach((role -> role.delete().complete()));
+        topics.remove(topic);
+    }
+
+    /**
+     * Gets all Topics from this Server
+     * @return An array of Topics
+     */
+    public Topic[] getTopics() {
+        return (Topic[]) topics.toArray();
+    }
+}

--- a/src/main/java/entities/Server.java
+++ b/src/main/java/entities/Server.java
@@ -23,23 +23,6 @@ public class Server {
     }
 
     /**
-     * Constructs a Server object from a Guild's role list.
-     * @param guild The guild to build from
-     * @return A Server with all topics added
-     */
-    public static Server load(Guild guild) {
-        Server server = new Server(guild);
-        List<Role> roles = guild.getRoles();
-        for (Role role : roles) {
-            String name = role.getName();
-            if (name.startsWith("Topic | ")) {
-                server.topics.add(new Topic(name.substring(8)));
-            }
-        }
-        return server;
-    }
-
-    /**
      * Creates a new Topic role in this server.
      * @param topic The Topic to add
      */
@@ -67,5 +50,22 @@ public class Server {
      */
     public Topic[] getTopics() {
         return topics.toArray(new Topic[0]);
+    }
+
+    /**
+     * Constructs a Server object from a Guild's role list.
+     * @param guild The guild to build from
+     * @return A Server with all topics added
+     */
+    public static Server load(Guild guild) {
+        Server server = new Server(guild);
+        List<Role> roles = guild.getRoles();
+        for (Role role : roles) {
+            String name = role.getName();
+            if (name.startsWith("Topic | ")) {
+                server.topics.add(new Topic(name.substring(8)));
+            }
+        }
+        return server;
     }
 }

--- a/src/main/java/entities/Server.java
+++ b/src/main/java/entities/Server.java
@@ -5,6 +5,7 @@ import net.dv8tion.jda.api.entities.Role;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * An object that provides Topic CRUD methods for a Guild.
@@ -66,6 +67,6 @@ public class Server {
      * @return An array of Topics
      */
     public Topic[] getTopics() {
-        return (Topic[]) topics.toArray();
+        return topics.toArray(new Topic[0]);
     }
 }

--- a/src/main/java/entities/Server.java
+++ b/src/main/java/entities/Server.java
@@ -5,7 +5,6 @@ import net.dv8tion.jda.api.entities.Role;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * An object that provides Topic CRUD methods for a Guild.

--- a/src/main/java/entities/Server.java
+++ b/src/main/java/entities/Server.java
@@ -61,6 +61,10 @@ public class Server {
      * @return An array of Topics
      */
     public Topic[] getTopics() {
+        /*
+         The Java runtime will automatically expand the passed-in array to fit the
+         contents of `topics` in a performant, thread-safe manner.
+         */
         return topics.toArray(new Topic[0]);
     }
 }

--- a/src/main/java/entities/Server.java
+++ b/src/main/java/entities/Server.java
@@ -14,8 +14,19 @@ public class Server {
     private final Guild guild;
     private final ArrayList<Topic> topics = new ArrayList<>();
 
+    /**
+     * Constructs a Server object from a Guild's role list.
+     * @param guild The Guild that this object is associated with
+     */
     public Server(Guild guild) {
         this.guild = guild;
+        List<Role> roles = guild.getRoles();
+        for (Role role : roles) {
+            String name = role.getName();
+            if (name.startsWith("Topic | ")) {
+                topics.add(new Topic(name.substring(8)));
+            }
+        }
     }
 
     @Override
@@ -51,22 +62,5 @@ public class Server {
      */
     public Topic[] getTopics() {
         return topics.toArray(new Topic[0]);
-    }
-
-    /**
-     * Constructs a Server object from a Guild's role list.
-     * @param guild The guild to build from
-     * @return A Server with all topics added
-     */
-    public static Server load(Guild guild) {
-        Server server = new Server(guild);
-        List<Role> roles = guild.getRoles();
-        for (Role role : roles) {
-            String name = role.getName();
-            if (name.startsWith("Topic | ")) {
-                server.topics.add(new Topic(name.substring(8)));
-            }
-        }
-        return server;
     }
 }

--- a/src/main/java/entities/Topic.java
+++ b/src/main/java/entities/Topic.java
@@ -1,0 +1,5 @@
+package entities;
+
+public class Topic {
+
+}

--- a/src/main/java/entities/Topic.java
+++ b/src/main/java/entities/Topic.java
@@ -37,6 +37,23 @@ public class Topic {
     }
 
     /**
+     * Check if a Member is inside the queue.
+     * @param member The Member to check
+     * @return True if the member is in the queue, false otherwise
+     */
+    public boolean isInQueue(Member member) {
+        return queue.contains(member);
+    }
+
+    /**
+     * Returns an array of all Members in the queue.
+     * @return The Members in this queue
+     */
+    public Member[] getMembersInQueue() {
+        return queue.toArray(new Member[0]);
+    }
+
+    /**
      * Remove and return the next Member in the queue.
      * @return The Member at the front of the queue
      */

--- a/src/main/java/entities/Topic.java
+++ b/src/main/java/entities/Topic.java
@@ -1,5 +1,54 @@
 package entities;
 
-public class Topic {
+import net.dv8tion.jda.api.entities.Member;
 
+import java.util.ArrayList;
+
+/**
+ * A topic for a server. Internally contains a queue of Members.
+ */
+public class Topic {
+    private final String name;
+    private final ArrayList<Member> queue = new ArrayList<>();
+
+    /**
+     * Constructs a new Topic object. This does not automatically create
+     * the topic on the Discord server.
+     * @param name The name of the topic.
+     */
+    public Topic(String name) {
+        this.name = name;
+    }
+
+    /**
+     * Add a Member to the back of the queue.
+     * @param member The Member to add
+     */
+    public void addToQueue(Member member) {
+        queue.add(member);
+    }
+
+    /**
+     * Remove a Member from their position in the queue.
+     * @param member The Member to remove
+     */
+    public void removeFromQueue(Member member) {
+        queue.remove(member);
+    }
+
+    /**
+     * Remove and return the next Member in the queue.
+     * @return The Member at the front of the queue
+     */
+    public Member getNextFromQueue() {
+        return queue.remove(0);
+    }
+
+    /**
+     * Get the name of this Topic.
+     * @return This Topic's name
+     */
+    public String getName() {
+        return name;
+    }
 }

--- a/src/main/java/entities/Topic.java
+++ b/src/main/java/entities/Topic.java
@@ -2,14 +2,14 @@ package entities;
 
 import net.dv8tion.jda.api.entities.Member;
 
-import java.util.ArrayList;
+import java.util.LinkedList;
 
 /**
  * A topic for a server. Internally contains a queue of Members.
  */
 public class Topic {
     private final String name;
-    private final ArrayList<Member> queue = new ArrayList<>();
+    private final LinkedList<Member> queue = new LinkedList<>();
 
     /**
      * Constructs a new Topic object. This does not automatically create
@@ -58,7 +58,7 @@ public class Topic {
      * @return The Member at the front of the queue
      */
     public Member getNextFromQueue() {
-        return queue.remove(0);
+        return queue.remove();
     }
 
     /**

--- a/src/main/java/launcher/Lehrry.java
+++ b/src/main/java/launcher/Lehrry.java
@@ -5,7 +5,6 @@ import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.JDABuilder;
 import net.dv8tion.jda.api.requests.GatewayIntent;
 import net.dv8tion.jda.api.utils.ChunkingFilter;
-import net.dv8tion.jda.api.utils.MemberCachePolicy;
 
 import javax.security.auth.login.LoginException;
 

--- a/src/main/java/launcher/Lehrry.java
+++ b/src/main/java/launcher/Lehrry.java
@@ -1,7 +1,24 @@
 package launcher;
 
+import listeners.MainEventListener;
+import net.dv8tion.jda.api.JDA;
+import net.dv8tion.jda.api.JDABuilder;
+import net.dv8tion.jda.api.requests.GatewayIntent;
+import net.dv8tion.jda.api.utils.ChunkingFilter;
+import net.dv8tion.jda.api.utils.MemberCachePolicy;
+
+import javax.security.auth.login.LoginException;
+
 public class Lehrry {
     public static void main(String[] args) {
-        System.out.println("hey!");
+        try {
+            JDA jda = JDABuilder.createDefault(System.getenv("LEHRRY_TOKEN"))
+                    .setChunkingFilter(ChunkingFilter.ALL)
+                    .enableIntents(GatewayIntent.GUILD_MESSAGES)
+                    .addEventListeners(new MainEventListener())
+                    .build();
+        } catch (LoginException ex) {
+            ex.printStackTrace();
+        }
     }
 }

--- a/src/main/java/launcher/Mentorbot.java
+++ b/src/main/java/launcher/Mentorbot.java
@@ -8,10 +8,10 @@ import net.dv8tion.jda.api.utils.ChunkingFilter;
 
 import javax.security.auth.login.LoginException;
 
-public class Lehrry {
+public class Mentorbot {
     public static void main(String[] args) {
         try {
-            JDA jda = JDABuilder.createDefault(System.getenv("LEHRRY_TOKEN"))
+            JDA jda = JDABuilder.createDefault(System.getenv("MENTORBOT_TOKEN"))
                     .setChunkingFilter(ChunkingFilter.ALL)
                     .enableIntents(GatewayIntent.GUILD_MESSAGES)
                     .addEventListeners(new MainEventListener())

--- a/src/main/java/listeners/MainEventListener.java
+++ b/src/main/java/listeners/MainEventListener.java
@@ -39,7 +39,7 @@ public class MainEventListener extends ListenerAdapter {
      */
     private static boolean checkAdmin(Member member, TextChannel channel) {
         if (!member.hasPermission(Permission.ADMINISTRATOR)) {
-            channel.sendMessage(member.getAsMention() + " You must have administrator permission to run this command.").complete();
+            channel.sendMessage(member.getAsMention() + " You must have administrator permission to run this command.").queue();
             return false;
         }
         return true;
@@ -61,7 +61,7 @@ public class MainEventListener extends ListenerAdapter {
             channel.sendMessage(String.format(
                     "%s Topic \"%s\" does not exist.",
                     member.getAsMention(),
-                    topic)).complete();
+                    topic)).queue();
         }
         return topicOptional;
     }
@@ -114,7 +114,7 @@ public class MainEventListener extends ListenerAdapter {
         embedBuilder.addField("$maketopic <name> (admin only)", "Create a new topic.", false);
         embedBuilder.addField("$deletetopic <name> (admin only)", "Delete a topic.", false);
 
-        channel.sendMessage(embedBuilder.build()).complete();
+        channel.sendMessage(embedBuilder.build()).queue();
     }
 
     private void maketopic(Member member, TextChannel channel, Server server, String[] args) {
@@ -126,7 +126,7 @@ public class MainEventListener extends ListenerAdapter {
         channel.sendMessage(String.format(
                 "%s Topic role \"%s\" has been created.",
                 member.getAsMention(),
-                args[0])).complete();
+                args[0])).queue();
     }
 
     private void deletetopic(Member member, TextChannel channel, Server server, String[] args) {
@@ -140,7 +140,7 @@ public class MainEventListener extends ListenerAdapter {
         channel.sendMessage(String.format(
                 "%s Topic role \"%s\" has been deleted.",
                 member.getAsMention(),
-                args[0])).complete();
+                args[0])).queue();
     }
 
     private void showtopics(Member member, TextChannel channel, Server server, String[] args) {
@@ -151,7 +151,7 @@ public class MainEventListener extends ListenerAdapter {
         channel.sendMessage(String.format(
                 "%s List of topics:\n%s",
                 member.getAsMention(),
-                topicList)).complete();
+                topicList)).queue();
     }
 
     private void queue(Member member, TextChannel channel, Server server, String[] args) {
@@ -164,13 +164,13 @@ public class MainEventListener extends ListenerAdapter {
             channel.sendMessage(String.format(
                     "%s has left the \"%s\" queue.",
                     member.getAsMention(),
-                    args[0])).complete();
+                    args[0])).queue();
         } else {
             topic.addToQueue(member);
             channel.sendMessage(String.format(
                     "%s has joined the \"%s\" queue.",
                     member.getAsMention(),
-                    args[0])).complete();
+                    args[0])).queue();
         }
     }
 
@@ -185,7 +185,7 @@ public class MainEventListener extends ListenerAdapter {
         channel.sendMessage(String.format(
                 "%s is ready for %s.",
                 member.getAsMention(),
-                mentee.getAsMention())).complete();
+                mentee.getAsMention())).queue();
     }
 
     private void showqueue(Member member, TextChannel channel, Server server, String[] args) {
@@ -197,7 +197,7 @@ public class MainEventListener extends ListenerAdapter {
             channel.sendMessage(String.format(
                     "%s Queue \"%s\" is empty.",
                     member.getAsMention(),
-                    topic.getName())).complete();
+                    topic.getName())).queue();
         } else {
             String menteeList = Arrays.stream(topic.getMembersInQueue())
                     .map(Member::getEffectiveName)
@@ -207,7 +207,7 @@ public class MainEventListener extends ListenerAdapter {
                     "%s Members in \"%s\" queue:\n%s",
                     member.getAsMention(),
                     topic.getName(),
-                    menteeList)).complete();
+                    menteeList)).queue();
         }
     }
 
@@ -223,10 +223,10 @@ public class MainEventListener extends ListenerAdapter {
         channel.sendMessage(String.format(
                 "%s has cleared the \"%s\" queue.",
                 member.getAsMention(),
-                topic.getName())).complete();
+                topic.getName())).queue();
     }
 
     private void unknownCommand(Member member, TextChannel channel, Server server, String[] args) {
-        channel.sendMessage(member.getAsMention() + " Command does not exist! Try $help for a list of valid commands.").complete();
+        channel.sendMessage(member.getAsMention() + " Command does not exist! Try $help for a list of valid commands.").queue();
     }
 }

--- a/src/main/java/listeners/MainEventListener.java
+++ b/src/main/java/listeners/MainEventListener.java
@@ -1,14 +1,65 @@
 package listeners;
 
+import entities.Server;
 import net.dv8tion.jda.api.entities.Activity;
+import net.dv8tion.jda.api.entities.Member;
+import net.dv8tion.jda.api.entities.TextChannel;
 import net.dv8tion.jda.api.events.ReadyEvent;
+import net.dv8tion.jda.api.events.message.guild.GuildMessageReceivedEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.*;
+
 public class MainEventListener extends ListenerAdapter {
+    /**
+     * A function that handles a single command.
+     */
+    private interface CommandHandler {
+        /**
+         * Handle a single command.
+         * @param member The member that called the command
+         * @param channel The channel that the command was called in
+         * @param server The Server that the command was called in
+         * @param args Extra command arguments, if any
+         */
+        void handle(@NotNull Member member, TextChannel channel, Server server, String[] args);
+    }
+
+    private final HashMap<String, Server> servers = new HashMap<>();
+
     @Override
     public void onReady(@NotNull ReadyEvent event) {
         System.out.println("Logged in");
         event.getJDA().getPresence().setPresence(Activity.playing("$help"), false);
+    }
+
+    @Override
+    public void onGuildMessageReceived(@NotNull GuildMessageReceivedEvent event) {
+        String[] tokens = event.getMessage().getContentDisplay().split(" ");
+        if (!tokens[0].startsWith("$")) return;
+
+        String guildID = event.getGuild().getId();
+        Server server = servers.computeIfAbsent(guildID, k -> Server.load(event.getGuild()));
+
+        // pick the correct method to call
+        CommandHandler commandHandler;
+        switch (tokens[0].substring(1)) {
+            case "help" -> commandHandler = this::help;
+            default -> commandHandler = this::unknownCommand;
+        }
+        commandHandler.handle(
+                Objects.requireNonNull(event.getMember()),
+                event.getChannel(),
+                server,
+                Arrays.copyOfRange(tokens, 1, tokens.length));
+    }
+
+    private void help(Member member, TextChannel channel, Server server, String[] args) {
+        channel.sendMessage(member.getAsMention() + " No commands implemented yet!").complete();
+    }
+
+    private void unknownCommand(Member member, TextChannel channel, Server server, String[] args) {
+        channel.sendMessage(member.getAsMention() + " Command does not exist! Try $help for a list of valid commands.").complete();
     }
 }

--- a/src/main/java/listeners/MainEventListener.java
+++ b/src/main/java/listeners/MainEventListener.java
@@ -82,7 +82,7 @@ public class MainEventListener extends ListenerAdapter {
         TextChannel channel = event.getChannel();
 
         String guildID = event.getGuild().getId();
-        Server server = servers.computeIfAbsent(guildID, k -> Server.load(event.getGuild()));
+        Server server = servers.computeIfAbsent(guildID, k -> new Server(event.getGuild()));
 
         // pick the correct method to call
         CommandHandler commandHandler;

--- a/src/main/java/listeners/MainEventListener.java
+++ b/src/main/java/listeners/MainEventListener.java
@@ -118,7 +118,7 @@ public class MainEventListener extends ListenerAdapter {
     }
 
     private void makeTopic(Member member, TextChannel channel, Server server, String[] args) {
-        if (!checkAdmin(member, channel)) return;
+        if (!checkAdmin(member, channel)) return;  // do not allow non-admins to run command
 
         Topic topic = new Topic(args[0]);
         server.createTopic(topic);
@@ -130,7 +130,7 @@ public class MainEventListener extends ListenerAdapter {
     }
 
     private void deleteTopic(Member member, TextChannel channel, Server server, String[] args) {
-        if (!checkAdmin(member, channel)) return;
+        if (!checkAdmin(member, channel)) return;  // do not allow non-admins to run command
 
         Arrays.stream(server.getTopics())                   // loop over all topics...
                 .filter(t -> t.getName().equals(args[0]))   // ...if this topic's name is args[0]...
@@ -155,6 +155,7 @@ public class MainEventListener extends ListenerAdapter {
     }
 
     private void queue(Member member, TextChannel channel, Server server, String[] args) {
+        // do not run if topic does not exist
         Optional<Topic> optionalTopic = checkTopicExists(member, channel, server, args[0]);
         if (optionalTopic.isEmpty()) return;
 
@@ -175,8 +176,9 @@ public class MainEventListener extends ListenerAdapter {
     }
 
     private void ready(Member member, TextChannel channel, Server server, String[] args) {
-        if (!checkAdmin(member, channel)) return;
+        if (!checkAdmin(member, channel)) return;  // do not allow non-admins to run command
 
+        // do not run if topic does not exist
         Optional<Topic> optionalTopic = checkTopicExists(member, channel, server, args[0]);
         if (optionalTopic.isEmpty()) return;
 
@@ -189,6 +191,7 @@ public class MainEventListener extends ListenerAdapter {
     }
 
     private void showQueue(Member member, TextChannel channel, Server server, String[] args) {
+        // do not run if topic does not exist
         Optional<Topic> optionalTopic = checkTopicExists(member, channel, server, args[0]);
         if (optionalTopic.isEmpty()) return;
 
@@ -212,8 +215,9 @@ public class MainEventListener extends ListenerAdapter {
     }
 
     private void clear(Member member, TextChannel channel, Server server, String[] args) {
-        if (!checkAdmin(member, channel)) return;
+        if (!checkAdmin(member, channel)) return;  // do not allow non-admins to run command
 
+        // do not run if topic does not exist
         Optional<Topic> optionalTopic = checkTopicExists(member, channel, server, args[0]);
         if (optionalTopic.isEmpty()) return;
 

--- a/src/main/java/listeners/MainEventListener.java
+++ b/src/main/java/listeners/MainEventListener.java
@@ -1,0 +1,14 @@
+package listeners;
+
+import net.dv8tion.jda.api.entities.Activity;
+import net.dv8tion.jda.api.events.ReadyEvent;
+import net.dv8tion.jda.api.hooks.ListenerAdapter;
+import org.jetbrains.annotations.NotNull;
+
+public class MainEventListener extends ListenerAdapter {
+    @Override
+    public void onReady(@NotNull ReadyEvent event) {
+        System.out.println("Logged in");
+        event.getJDA().getPresence().setPresence(Activity.playing("$help"), false);
+    }
+}

--- a/src/main/java/listeners/MainEventListener.java
+++ b/src/main/java/listeners/MainEventListener.java
@@ -5,7 +5,6 @@ import entities.Topic;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.Permission;
 import net.dv8tion.jda.api.entities.Activity;
-import net.dv8tion.jda.api.entities.GuildChannel;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.TextChannel;
 import net.dv8tion.jda.api.events.ReadyEvent;
@@ -55,16 +54,16 @@ public class MainEventListener extends ListenerAdapter {
      * @return Contains the Topic, if it exists
      */
     private static Optional<Topic> checkTopicExists(Member member, TextChannel channel, Server server, String topic) {
-        Optional<Topic> topicOptional = Arrays.stream(server.getTopics())
+        Optional<Topic> optionalTopic = Arrays.stream(server.getTopics())
                 .filter(t -> t.getName().equalsIgnoreCase(topic))
                 .findFirst();
-        if (topicOptional.isEmpty()) {
+        if (optionalTopic.isEmpty()) {
             channel.sendMessage(String.format(
                     "%s Topic \"%s\" does not exist.",
                     member.getAsMention(),
                     topic)).queue();
         }
-        return topicOptional;
+        return optionalTopic;
     }
 
     @Override
@@ -156,10 +155,10 @@ public class MainEventListener extends ListenerAdapter {
     }
 
     private void queue(Member member, TextChannel channel, Server server, String[] args) {
-        Optional<Topic> topicOptional = checkTopicExists(member, channel, server, args[0]);
-        if (topicOptional.isEmpty()) return;
+        Optional<Topic> optionalTopic = checkTopicExists(member, channel, server, args[0]);
+        if (optionalTopic.isEmpty()) return;
 
-        Topic topic = topicOptional.get();
+        Topic topic = optionalTopic.get();
         if (topic.isInQueue(member)) {
             topic.removeFromQueue(member);
             channel.sendMessage(String.format(
@@ -178,10 +177,10 @@ public class MainEventListener extends ListenerAdapter {
     private void ready(Member member, TextChannel channel, Server server, String[] args) {
         if (!checkAdmin(member, channel)) return;
 
-        Optional<Topic> topicOptional = checkTopicExists(member, channel, server, args[0]);
-        if (topicOptional.isEmpty()) return;
+        Optional<Topic> optionalTopic = checkTopicExists(member, channel, server, args[0]);
+        if (optionalTopic.isEmpty()) return;
 
-        Topic topic = topicOptional.get();
+        Topic topic = optionalTopic.get();
         Member mentee = topic.getNextFromQueue();
         channel.sendMessage(String.format(
                 "%s is ready for %s.",
@@ -190,10 +189,10 @@ public class MainEventListener extends ListenerAdapter {
     }
 
     private void showQueue(Member member, TextChannel channel, Server server, String[] args) {
-        Optional<Topic> topicOptional = checkTopicExists(member, channel, server, args[0]);
-        if (topicOptional.isEmpty()) return;
+        Optional<Topic> optionalTopic = checkTopicExists(member, channel, server, args[0]);
+        if (optionalTopic.isEmpty()) return;
 
-        Topic topic = topicOptional.get();
+        Topic topic = optionalTopic.get();
         if (topic.getMembersInQueue().length == 0) {
             channel.sendMessage(String.format(
                     "%s Queue \"%s\" is empty.",
@@ -215,10 +214,10 @@ public class MainEventListener extends ListenerAdapter {
     private void clear(Member member, TextChannel channel, Server server, String[] args) {
         if (!checkAdmin(member, channel)) return;
 
-        Optional<Topic> topicOptional = checkTopicExists(member, channel, server, args[0]);
-        if (topicOptional.isEmpty()) return;
+        Optional<Topic> optionalTopic = checkTopicExists(member, channel, server, args[0]);
+        if (optionalTopic.isEmpty()) return;
 
-        Topic topic = topicOptional.get();
+        Topic topic = optionalTopic.get();
         Arrays.stream(topic.getMembersInQueue()).forEach(topic::removeFromQueue);
 
         channel.sendMessage(String.format(

--- a/src/main/java/listeners/MainEventListener.java
+++ b/src/main/java/listeners/MainEventListener.java
@@ -2,6 +2,7 @@ package listeners;
 
 import entities.Server;
 import entities.Topic;
+import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.Permission;
 import net.dv8tion.jda.api.entities.Activity;
 import net.dv8tion.jda.api.entities.Member;
@@ -99,7 +100,19 @@ public class MainEventListener extends ListenerAdapter {
     }
 
     private void help(Member member, TextChannel channel, Server server, String[] args) {
-        channel.sendMessage(member.getAsMention() + " No commands implemented yet!").complete();
+        EmbedBuilder embedBuilder = new EmbedBuilder();
+        embedBuilder.setTitle("Help!");
+        embedBuilder.setDescription("Possible commands:");
+        embedBuilder.setColor(0xE57D25);
+
+        embedBuilder.addField("$queue <topic>", "Add yourself to a queue.", false);
+        embedBuilder.addField("$showqueue <topic>", "Show the people currently in queue.", false);
+        embedBuilder.addField("$showtopics", "List all topics.", false);
+        embedBuilder.addField("$ready <topic> (admin only)", "Retrieve the next person from the queue.", false);
+        embedBuilder.addField("$maketopic <name> (admin only)", "Create a new topic.", false);
+        embedBuilder.addField("$deletetopic <name> (admin only)", "Delete a topic.", false);
+
+        channel.sendMessage(embedBuilder.build()).complete();
     }
 
     private void maketopic(Member member, TextChannel channel, Server server, String[] args) {

--- a/src/main/java/listeners/MainEventListener.java
+++ b/src/main/java/listeners/MainEventListener.java
@@ -5,6 +5,7 @@ import entities.Topic;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.Permission;
 import net.dv8tion.jda.api.entities.Activity;
+import net.dv8tion.jda.api.entities.GuildChannel;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.TextChannel;
 import net.dv8tion.jda.api.events.ReadyEvent;
@@ -76,6 +77,10 @@ public class MainEventListener extends ListenerAdapter {
     public void onGuildMessageReceived(@NotNull GuildMessageReceivedEvent event) {
         String[] tokens = event.getMessage().getContentDisplay().split(" ");
         if (!tokens[0].startsWith("$")) return;
+        String[] args = Arrays.copyOfRange(tokens, 1, tokens.length);
+
+        Member member = Objects.requireNonNull(event.getMember());
+        TextChannel channel = event.getChannel();
 
         String guildID = event.getGuild().getId();
         Server server = servers.computeIfAbsent(guildID, k -> Server.load(event.getGuild()));
@@ -93,11 +98,7 @@ public class MainEventListener extends ListenerAdapter {
             case "clear" -> commandHandler = this::clear;
             default -> commandHandler = this::unknownCommand;
         }
-        commandHandler.handle(
-                Objects.requireNonNull(event.getMember()),
-                event.getChannel(),
-                server,
-                Arrays.copyOfRange(tokens, 1, tokens.length));
+        commandHandler.handle(member, channel, server, args);
     }
 
     private void help(Member member, TextChannel channel, Server server, String[] args) {

--- a/src/main/java/listeners/MainEventListener.java
+++ b/src/main/java/listeners/MainEventListener.java
@@ -88,15 +88,15 @@ public class MainEventListener extends ListenerAdapter {
         // pick the correct method to call
         CommandHandler commandHandler;
         switch (tokens[0].substring(1)) {
-            case "help" -> commandHandler = this::help;
-            case "maketopic" -> commandHandler = this::makeTopic;
+            case "help"        -> commandHandler = this::help;
+            case "maketopic"   -> commandHandler = this::makeTopic;
             case "deletetopic" -> commandHandler = this::deleteTopic;
-            case "showtopics" -> commandHandler = this::showTopics;
-            case "queue" -> commandHandler = this::queue;
-            case "ready" -> commandHandler = this::ready;
-            case "showqueue" -> commandHandler = this::showQueue;
-            case "clear" -> commandHandler = this::clear;
-            default -> commandHandler = this::unknownCommand;
+            case "showtopics"  -> commandHandler = this::showTopics;
+            case "queue"       -> commandHandler = this::queue;
+            case "ready"       -> commandHandler = this::ready;
+            case "showqueue"   -> commandHandler = this::showQueue;
+            case "clear"       -> commandHandler = this::clear;
+            default            -> commandHandler = this::unknownCommand;
         }
         commandHandler.handle(member, channel, server, args);
     }

--- a/src/main/java/listeners/MainEventListener.java
+++ b/src/main/java/listeners/MainEventListener.java
@@ -84,12 +84,12 @@ public class MainEventListener extends ListenerAdapter {
         CommandHandler commandHandler;
         switch (tokens[0].substring(1)) {
             case "help" -> commandHandler = this::help;
-            case "maketopic" -> commandHandler = this::maketopic;
-            case "deletetopic" -> commandHandler = this::deletetopic;
-            case "showtopics" -> commandHandler = this::showtopics;
+            case "maketopic" -> commandHandler = this::makeTopic;
+            case "deletetopic" -> commandHandler = this::deleteTopic;
+            case "showtopics" -> commandHandler = this::showTopics;
             case "queue" -> commandHandler = this::queue;
             case "ready" -> commandHandler = this::ready;
-            case "showqueue" -> commandHandler = this::showqueue;
+            case "showqueue" -> commandHandler = this::showQueue;
             case "clear" -> commandHandler = this::clear;
             default -> commandHandler = this::unknownCommand;
         }
@@ -117,7 +117,7 @@ public class MainEventListener extends ListenerAdapter {
         channel.sendMessage(embedBuilder.build()).queue();
     }
 
-    private void maketopic(Member member, TextChannel channel, Server server, String[] args) {
+    private void makeTopic(Member member, TextChannel channel, Server server, String[] args) {
         if (!checkAdmin(member, channel)) return;
 
         Topic topic = new Topic(args[0]);
@@ -129,7 +129,7 @@ public class MainEventListener extends ListenerAdapter {
                 args[0])).queue();
     }
 
-    private void deletetopic(Member member, TextChannel channel, Server server, String[] args) {
+    private void deleteTopic(Member member, TextChannel channel, Server server, String[] args) {
         if (!checkAdmin(member, channel)) return;
 
         Arrays.stream(server.getTopics())                   // loop over all topics...
@@ -143,7 +143,7 @@ public class MainEventListener extends ListenerAdapter {
                 args[0])).queue();
     }
 
-    private void showtopics(Member member, TextChannel channel, Server server, String[] args) {
+    private void showTopics(Member member, TextChannel channel, Server server, String[] args) {
         String topicList = Arrays.stream(server.getTopics())
                 .map(Topic::getName)
                 .collect(Collectors.joining("\n"));
@@ -188,7 +188,7 @@ public class MainEventListener extends ListenerAdapter {
                 mentee.getAsMention())).queue();
     }
 
-    private void showqueue(Member member, TextChannel channel, Server server, String[] args) {
+    private void showQueue(Member member, TextChannel channel, Server server, String[] args) {
         Optional<Topic> topicOptional = checkTopicExists(member, channel, server, args[0]);
         if (topicOptional.isEmpty()) return;
 

--- a/src/main/java/listeners/MainEventListener.java
+++ b/src/main/java/listeners/MainEventListener.java
@@ -120,7 +120,9 @@ public class MainEventListener extends ListenerAdapter {
     private void makeTopic(Member member, TextChannel channel, Server server, String[] args) {
         if (!checkAdmin(member, channel)) return;  // do not allow non-admins to run command
 
-        Topic topic = new Topic(args[0]);
+        String topicName = args[0];
+
+        Topic topic = new Topic(topicName);
         server.createTopic(topic);
 
         channel.sendMessage(String.format(
@@ -132,8 +134,10 @@ public class MainEventListener extends ListenerAdapter {
     private void deleteTopic(Member member, TextChannel channel, Server server, String[] args) {
         if (!checkAdmin(member, channel)) return;  // do not allow non-admins to run command
 
+        String topicName = args[0];
+
         Arrays.stream(server.getTopics())                   // loop over all topics...
-                .filter(t -> t.getName().equals(args[0]))   // ...if this topic's name is args[0]...
+                .filter(t -> t.getName().equals(topicName))   // ...if this topic's name is args[0]...
                 .findFirst()
                 .ifPresent(server::deleteTopic);            // ...delete it
 
@@ -155,8 +159,10 @@ public class MainEventListener extends ListenerAdapter {
     }
 
     private void queue(Member member, TextChannel channel, Server server, String[] args) {
+        String topicName = args[0];
+
         // do not run if topic does not exist
-        Optional<Topic> optionalTopic = checkTopicExists(member, channel, server, args[0]);
+        Optional<Topic> optionalTopic = checkTopicExists(member, channel, server, topicName);
         if (optionalTopic.isEmpty()) return;
 
         Topic topic = optionalTopic.get();
@@ -165,21 +171,23 @@ public class MainEventListener extends ListenerAdapter {
             channel.sendMessage(String.format(
                     "%s has left the \"%s\" queue.",
                     member.getAsMention(),
-                    args[0])).queue();
+                    topicName)).queue();
         } else {
             topic.addToQueue(member);
             channel.sendMessage(String.format(
                     "%s has joined the \"%s\" queue.",
                     member.getAsMention(),
-                    args[0])).queue();
+                    topicName)).queue();
         }
     }
 
     private void ready(Member member, TextChannel channel, Server server, String[] args) {
         if (!checkAdmin(member, channel)) return;  // do not allow non-admins to run command
 
+        String topicName = args[0];
+
         // do not run if topic does not exist
-        Optional<Topic> optionalTopic = checkTopicExists(member, channel, server, args[0]);
+        Optional<Topic> optionalTopic = checkTopicExists(member, channel, server, topicName);
         if (optionalTopic.isEmpty()) return;
 
         Topic topic = optionalTopic.get();
@@ -191,8 +199,10 @@ public class MainEventListener extends ListenerAdapter {
     }
 
     private void showQueue(Member member, TextChannel channel, Server server, String[] args) {
+        String topicName = args[0];
+
         // do not run if topic does not exist
-        Optional<Topic> optionalTopic = checkTopicExists(member, channel, server, args[0]);
+        Optional<Topic> optionalTopic = checkTopicExists(member, channel, server, topicName);
         if (optionalTopic.isEmpty()) return;
 
         Topic topic = optionalTopic.get();
@@ -217,8 +227,10 @@ public class MainEventListener extends ListenerAdapter {
     private void clear(Member member, TextChannel channel, Server server, String[] args) {
         if (!checkAdmin(member, channel)) return;  // do not allow non-admins to run command
 
+        String topicName = args[0];
+
         // do not run if topic does not exist
-        Optional<Topic> optionalTopic = checkTopicExists(member, channel, server, args[0]);
+        Optional<Topic> optionalTopic = checkTopicExists(member, channel, server, topicName);
         if (optionalTopic.isEmpty()) return;
 
         Topic topic = optionalTopic.get();

--- a/src/main/java/listeners/MainEventListener.java
+++ b/src/main/java/listeners/MainEventListener.java
@@ -90,6 +90,7 @@ public class MainEventListener extends ListenerAdapter {
             case "queue" -> commandHandler = this::queue;
             case "ready" -> commandHandler = this::ready;
             case "showqueue" -> commandHandler = this::showqueue;
+            case "clear" -> commandHandler = this::clear;
             default -> commandHandler = this::unknownCommand;
         }
         commandHandler.handle(
@@ -109,6 +110,7 @@ public class MainEventListener extends ListenerAdapter {
         embedBuilder.addField("$showqueue <topic>", "Show the people currently in queue.", false);
         embedBuilder.addField("$showtopics", "List all topics.", false);
         embedBuilder.addField("$ready <topic> (admin only)", "Retrieve the next person from the queue.", false);
+        embedBuilder.addField("$clear <topic> (admin only)", "Clear the specified queue.", false);
         embedBuilder.addField("$maketopic <name> (admin only)", "Create a new topic.", false);
         embedBuilder.addField("$deletetopic <name> (admin only)", "Delete a topic.", false);
 
@@ -207,6 +209,21 @@ public class MainEventListener extends ListenerAdapter {
                     topic.getName(),
                     menteeList)).complete();
         }
+    }
+
+    private void clear(Member member, TextChannel channel, Server server, String[] args) {
+        if (!checkAdmin(member, channel)) return;
+
+        Optional<Topic> topicOptional = checkTopicExists(member, channel, server, args[0]);
+        if (topicOptional.isEmpty()) return;
+
+        Topic topic = topicOptional.get();
+        Arrays.stream(topic.getMembersInQueue()).forEach(topic::removeFromQueue);
+
+        channel.sendMessage(String.format(
+                "%s has cleared the \"%s\" queue.",
+                member.getAsMention(),
+                topic.getName())).complete();
     }
 
     private void unknownCommand(Member member, TextChannel channel, Server server, String[] args) {


### PR DESCRIPTION
Closes #2. This is a full re-implementation of [the Python bot](https://github.com/codeRIT/lehrbot). It is not an identical copy; most notably, it features [server-unique topic names](https://github.com/codeRIT/lehrbot/issues/3) and [uses "topic" instead of "class"](https://github.com/codeRIT/lehrbot/issues/1). I will copy the other GitHub issues over from the old repository after this PR is closed.