### PR TITLE
feat: Mentoring rooms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,7 +40,10 @@ gradle-app.setting
 # Cache of project
 .gradletasknamecache
 
-
-
 ## INTELLIJ - custom
 /.idea/
+
+# VSCode language server files
+.classpath
+.project
+org.eclipse.buildship.core.prefs

--- a/src/main/java/entities/Room.java
+++ b/src/main/java/entities/Room.java
@@ -1,0 +1,80 @@
+package entities;
+
+import java.util.Optional;
+
+import net.dv8tion.jda.api.entities.Category;
+import net.dv8tion.jda.api.entities.Invite;
+import net.dv8tion.jda.api.entities.Member;
+import net.dv8tion.jda.api.entities.TextChannel;
+import net.dv8tion.jda.api.entities.VoiceChannel;
+import net.dv8tion.jda.api.requests.restaction.InviteAction;
+
+public class Room {
+    private final Category category;
+    private final String name;
+    private final int number;
+    private final Member mentee;
+
+    private final TextChannel textChannel;
+    private final VoiceChannel voiceChannel;
+
+    public Room(Topic topic, int number, Member mentee) {
+        this.category = topic.getCategory();
+        this.name = String.format("%s-%d", topic.getName(), number);
+        this.number = number;
+        this.mentee = mentee;
+
+        deleteExisting();
+
+        // TODO: restrict permissions
+        textChannel = category.createTextChannel(name).complete();
+        textChannel.putPermissionOverride(mentee).complete();
+
+        voiceChannel = category.createVoiceChannel(name).complete();
+        voiceChannel.putPermissionOverride(mentee).complete();
+    }
+
+    public void delete() {
+        textChannel.delete().complete();
+        voiceChannel.delete().complete();
+    }
+
+    public void deleteExisting() {
+        Optional<TextChannel> optionalTextChannel = category.getTextChannels().stream()
+            .filter(tc -> tc.getName().equals(name.toLowerCase()))  // text channels are lowercase
+            .findFirst();
+        optionalTextChannel.ifPresent(tc -> tc.delete().complete());
+
+        Optional<VoiceChannel> optionalVoiceChannel = category.getVoiceChannels().stream()
+            .filter(vc -> vc.getName().equals(name))
+            .findFirst();
+        optionalVoiceChannel.ifPresent(vc -> vc.delete().complete());
+    }
+
+    public Invite getVoiceChannelInvite() {
+        InviteAction action = voiceChannel.createInvite();
+        action.setMaxAge(5 * 60);  // 5 minutes, to prevent hitting the invite cap
+        action.setMaxUses(2);
+        return action.complete();
+    }
+
+    public Member getMentee() {
+        return this.mentee;
+    }
+
+    public TextChannel getTextChannel() {
+        return this.textChannel;
+    }
+
+    public VoiceChannel getVoiceChannel() {
+        return this.voiceChannel;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public int getNumber() {
+        return number;
+    }
+}

--- a/src/main/java/entities/Room.java
+++ b/src/main/java/entities/Room.java
@@ -28,6 +28,7 @@ public class Room {
     /**
      * Create a new room. Existing channels for this room number (e.g. from
      * before a bot restart) will be deleted automatically.
+     * 
      * @param topic The Topic for this room
      * @param number This room's number
      * @param mentee The mentee using this room
@@ -58,6 +59,7 @@ public class Room {
 
     /**
      * Create a Room name from a Topic name and room number.
+     * 
      * @param topicName The name of the owning Topic
      * @param roomNumber The room's number
      * @return The Room's name
@@ -69,6 +71,7 @@ public class Room {
     /**
      * Deny view permissions to `everyoneRole` and allow view permissions to
      * all roles/members in `allowList`.
+     * 
      * @param channel The channel to apply permission overrides to 
      * @param everyoneRole Reference to `@everyone` role
      * @param allowList List of roles/members that should have access to this
@@ -113,6 +116,7 @@ public class Room {
     /**
      * Create an invite to this room's voice channel. This invite can be used
      * twice and expires after 5 minutes.
+     * 
      * @return A new Invite for this room's voice channel
      */
     public Invite getVoiceChannelInvite() {
@@ -124,6 +128,7 @@ public class Room {
 
     /**
      * Get this room's text channel
+     * 
      * @return This room's text channel
      */
     public TextChannel getTextChannel() {
@@ -132,6 +137,7 @@ public class Room {
 
     /**
      * Get this room's voice channel
+     * 
      * @return This room's voice channel
      */
     public VoiceChannel getVoiceChannel() {
@@ -140,6 +146,7 @@ public class Room {
 
     /**
      * Get this room's name
+     * 
      * @return This room's name
      */
     public String getName() {

--- a/src/main/java/entities/Room.java
+++ b/src/main/java/entities/Room.java
@@ -30,7 +30,7 @@ public class Room {
     /**
      * Create a new room. Existing channels for this room number (e.g. from
      * before a bot restart) will be deleted automatically.
-     * 
+     *
      * @param topic The Topic for this room
      * @param number This room's number
      * @param mentee The mentee using this room
@@ -44,16 +44,12 @@ public class Room {
 
         textChannel = category.createTextChannel(name).complete();
         Guild guild = textChannel.getGuild();
-        ArrayList<IPermissionHolder> allowList = new ArrayList<IPermissionHolder>() {
-            // makes the linter stop complaining about not having a version UID
-            private static final long serialVersionUID = 1L;
 
-            {
-                add(guild.getMember(guild.getJDA().getSelfUser()));  // allow the bot itself
-                add(topic.getRole());  // allow this topics' mentors
-                add(mentee);  // allow the mentee
-            }
-        };
+        ArrayList<IPermissionHolder> allowList = new ArrayList<IPermissionHolder>();
+        allowList.add(guild.getMember(guild.getJDA().getSelfUser()));  // allow the bot itself
+        allowList.add(topic.getRole());  // allow this topics' mentors
+        allowList.add(mentee);  // allow the mentee
+
         setChannelPermissions(textChannel, guild.getPublicRole(), allowList);
 
         voiceChannel = category.createVoiceChannel(name).complete();
@@ -63,8 +59,8 @@ public class Room {
     /**
      * Deny view permissions to `everyoneRole` and allow view permissions to
      * all roles/members in `allowList`.
-     * 
-     * @param channel The channel to apply permission overrides to 
+     *
+     * @param channel The channel to apply permission overrides to
      * @param everyoneRole Reference to `@everyone` role
      * @param allowList List of roles/members that should have access to this
      *     channel. The bot's user MUST be in this list.
@@ -108,7 +104,7 @@ public class Room {
     /**
      * Create an invite to this room's voice channel. This invite can be used
      * twice and expires after 5 minutes.
-     * 
+     *
      * @return A new Invite for this room's voice channel
      */
     public Invite getVoiceChannelInvite() {
@@ -120,7 +116,7 @@ public class Room {
 
     /**
      * Get this room's text channel
-     * 
+     *
      * @return This room's text channel
      */
     public TextChannel getTextChannel() {
@@ -129,7 +125,7 @@ public class Room {
 
     /**
      * Get this room's voice channel
-     * 
+     *
      * @return This room's voice channel
      */
     public VoiceChannel getVoiceChannel() {
@@ -138,7 +134,7 @@ public class Room {
 
     /**
      * Get this room's name
-     * 
+     *
      * @return This room's name
      */
     public String getName() {

--- a/src/main/java/entities/Room.java
+++ b/src/main/java/entities/Room.java
@@ -15,25 +15,14 @@ import net.dv8tion.jda.api.entities.TextChannel;
 import net.dv8tion.jda.api.entities.VoiceChannel;
 import net.dv8tion.jda.api.requests.restaction.InviteAction;
 
+/**
+ * A logical group for a topic's text and voice channels. All mentor-mentee
+ * interactions occur within a mentoring room.
+ */
 public class Room {
-    /**
-     * The Category that this room's channels exist within
-     */
     private final Category category;
-
-    /**
-     * The name of this room
-     */
     private final String name;
-
-    /**
-     * The text channel for this room
-     */
     private final TextChannel textChannel;
-
-    /**
-     * The voice channel for this room
-     */
     private final VoiceChannel voiceChannel;
 
     /**
@@ -78,8 +67,8 @@ public class Room {
     }
 
     /**
-     * Deny view permissions to `veryoneRole` and allow view permissions to all
-     * roles/members in `allowList`.
+     * Deny view permissions to `everyoneRole` and allow view permissions to
+     * all roles/members in `allowList`.
      * @param channel The channel to apply permission overrides to 
      * @param everyoneRole Reference to `@everyone` role
      * @param allowList List of roles/members that should have access to this

--- a/src/main/java/entities/Room.java
+++ b/src/main/java/entities/Room.java
@@ -118,7 +118,7 @@ public class Room {
     public Invite getVoiceChannelInvite() {
         InviteAction action = voiceChannel.createInvite();
         action.setMaxAge(5 * 60);  // 5 minutes, to prevent hitting the invite cap
-        action.setMaxUses(2);
+        action.setMaxUses(5);
         return action.complete();
     }
 

--- a/src/main/java/entities/Room.java
+++ b/src/main/java/entities/Room.java
@@ -25,6 +25,8 @@ public class Room {
     private final TextChannel textChannel;
     private final VoiceChannel voiceChannel;
 
+    private static int nextRoomNumber = 1;
+
     /**
      * Create a new room. Existing channels for this room number (e.g. from
      * before a bot restart) will be deleted automatically.
@@ -33,9 +35,10 @@ public class Room {
      * @param number This room's number
      * @param mentee The mentee using this room
      */
-    public Room(Topic topic, int number, Member mentee) {
+    public Room(Topic topic, Member mentee) {
         this.category = topic.getCategory();
-        this.name = makeName(topic.getName(), number);
+        this.name = String.format("%s-%d", topic.getName(), nextRoomNumber);
+        nextRoomNumber++;
 
         deleteExisting();
 
@@ -55,17 +58,6 @@ public class Room {
 
         voiceChannel = category.createVoiceChannel(name).complete();
         setChannelPermissions(voiceChannel, guild.getPublicRole(), allowList);
-    }
-
-    /**
-     * Create a Room name from a Topic name and room number.
-     * 
-     * @param topicName The name of the owning Topic
-     * @param roomNumber The room's number
-     * @return The Room's name
-     */
-    public static String makeName(String topicName, int roomNumber) {
-        return String.format("%s-%d", topicName, roomNumber);
     }
 
     /**

--- a/src/main/java/entities/Room.java
+++ b/src/main/java/entities/Room.java
@@ -26,7 +26,7 @@ public class Room {
 
     public Room(Topic topic, int number, Member mentee) {
         this.category = topic.getCategory();
-        this.name = String.format("%s-%d", topic.getName(), number);
+        this.name = makeName(topic.getName(), number);
         this.number = number;
         this.mentee = mentee;
 
@@ -47,6 +47,16 @@ public class Room {
         setChannelPermissions(textChannel, guild.getPublicRole(), allowList);
 
         voiceChannel = category.createVoiceChannel(name).complete();
+    }
+
+    /**
+     * Create a Room name from a Topic name and room number.
+     * @param topicName The name of the owning Topic
+     * @param roomNumber The room's number
+     * @return The Room's name
+     */
+    public static String makeName(String topicName, int roomNumber) {
+        return String.format("%s-%d", topicName, roomNumber);
     }
 
     private void setChannelPermissions(GuildChannel channel, IPermissionHolder everyoneRole, Collection<IPermissionHolder> allowList) {

--- a/src/main/java/entities/Server.java
+++ b/src/main/java/entities/Server.java
@@ -14,14 +14,7 @@ public class Server {
     public static final String TOPIC_PREFIX = "Topic | ";
     public static final String MENTORING_CATEGORY_NAME = "Mentoring";
 
-    /**
-     * The Guild that this Server represents
-     */
     private final Guild guild;
-
-    /**
-     * The Category to place mentoring rooms into
-     */
     private final Category mentoringCategory;
 
     /**

--- a/src/main/java/entities/Server.java
+++ b/src/main/java/entities/Server.java
@@ -36,7 +36,7 @@ public class Server {
         for (Role role : roles) {
             String name = role.getName();
             if (name.startsWith(TOPIC_PREFIX)) {
-                topics.put(name.substring(8), new Topic(name.substring(8), role, category));
+                topics.put(name.substring(8).toLowerCase(), new Topic(name.substring(8), role, category));
             }
         }
     }
@@ -73,7 +73,7 @@ public class Server {
      * @param topicName The name of the Topic to remove
      */
     public void deleteTopic(String topicName) {
-        deleteTopic(topics.get(topicName));
+        deleteTopic(topics.get(topicName.toLowerCase()));
     }
 
     /**
@@ -94,6 +94,6 @@ public class Server {
      * @return The Topic object, or null if the Topic does not exist
      */
     public Optional<Topic> getTopic(String topicName) {
-        return Optional.ofNullable(topics.get(topicName));
+        return Optional.ofNullable(topics.get(topicName.toLowerCase()));
     }
 }

--- a/src/main/java/entities/Server.java
+++ b/src/main/java/entities/Server.java
@@ -14,8 +14,19 @@ public class Server {
     public static final String TOPIC_PREFIX = "Topic | ";
     public static final String MENTORING_CATEGORY_NAME = "Mentoring";
 
+    /**
+     * The Guild that this Server represents
+     */
     private final Guild guild;
-    private final Category category;
+
+    /**
+     * The Category to place mentoring rooms into
+     */
+    private final Category mentoringCategory;
+
+    /**
+     * Map from topic names to Topic objects
+     */
     private final HashMap<String, Topic> topics = new HashMap<>();
 
     /**
@@ -29,18 +40,22 @@ public class Server {
         Optional<Category> optionalCategory = guild.getCategoriesByName(MENTORING_CATEGORY_NAME, false)
             .stream()
             .findFirst();
-        category = optionalCategory.orElseGet(() -> guild.createCategory(MENTORING_CATEGORY_NAME).complete());
+        mentoringCategory = optionalCategory.orElseGet(() -> guild.createCategory(MENTORING_CATEGORY_NAME).complete());
 
         // setup roles
         List<Role> roles = guild.getRoles();
         for (Role role : roles) {
             String name = role.getName();
             if (name.startsWith(TOPIC_PREFIX)) {
-                topics.put(name.substring(8).toLowerCase(), new Topic(name.substring(8), role, category));
+                topics.put(name.substring(8).toLowerCase(), new Topic(name.substring(8), role, mentoringCategory));
             }
         }
     }
 
+    /**
+     * Used for comparison between two Server objects. Servers pointing
+     * to the same Guild object return the same hash.
+     */
     @Override
     public int hashCode() {
         return guild.getName().hashCode();
@@ -54,7 +69,7 @@ public class Server {
         guild.createRole()
                 .setName(TOPIC_PREFIX + topicName)
                 .setMentionable(true)
-                .queue(role -> topics.put(topicName, new Topic(topicName, role, category)));
+                .queue(role -> topics.put(topicName, new Topic(topicName, role, mentoringCategory)));
     }
 
     /**

--- a/src/main/java/entities/Server.java
+++ b/src/main/java/entities/Server.java
@@ -3,7 +3,6 @@ package entities;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.Role;
 
-import javax.swing.text.html.Option;
 import java.util.*;
 
 /**

--- a/src/main/java/entities/Server.java
+++ b/src/main/java/entities/Server.java
@@ -24,6 +24,7 @@ public class Server {
 
     /**
      * Constructs a Server object from a Guild's role list.
+     * 
      * @param guild The Guild that this object is associated with
      */
     public Server(Guild guild) {
@@ -56,6 +57,7 @@ public class Server {
 
     /**
      * Creates a new Topic role in this server.
+     * 
      * @param topicName The name for the new topic
      */
     public void createTopic(String topicName) {
@@ -67,6 +69,7 @@ public class Server {
 
     /**
      * Deletes the Topic role from this server.
+     * 
      * @param topic The Topic to remove
      */
     public void deleteTopic(Topic topic) {
@@ -78,6 +81,7 @@ public class Server {
 
     /**
      * Deletes the Topic role from this server.
+     * 
      * @param topicName The name of the Topic to remove
      */
     public void deleteTopic(String topicName) {
@@ -86,6 +90,7 @@ public class Server {
 
     /**
      * Gets all Topics from this Server
+     * 
      * @return An array of Topics
      */
     public Topic[] getTopics() {
@@ -98,7 +103,9 @@ public class Server {
 
     /**
      * Gets the Topic with the specified name
+     * 
      * @param topicName The name of the Topic to retrieve
+     * 
      * @return The Topic object, or null if the Topic does not exist
      */
     public Optional<Topic> getTopic(String topicName) {

--- a/src/main/java/entities/Server.java
+++ b/src/main/java/entities/Server.java
@@ -1,5 +1,6 @@
 package entities;
 
+import net.dv8tion.jda.api.entities.Category;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.Role;
 
@@ -11,8 +12,10 @@ import java.util.*;
  */
 public class Server {
     public static final String TOPIC_PREFIX = "Topic | ";
+    public static final String MENTORING_CATEGORY_NAME = "Mentoring";
 
     private final Guild guild;
+    private final Category category;
     private final HashMap<String, Topic> topics = new HashMap<>();
 
     /**
@@ -21,11 +24,19 @@ public class Server {
      */
     public Server(Guild guild) {
         this.guild = guild;
+
+        // setup mentoring channel category
+        Optional<Category> optionalCategory = guild.getCategoriesByName(MENTORING_CATEGORY_NAME, false)
+            .stream()
+            .findFirst();
+        category = optionalCategory.orElseGet(() -> guild.createCategory(MENTORING_CATEGORY_NAME).complete());
+
+        // setup roles
         List<Role> roles = guild.getRoles();
         for (Role role : roles) {
             String name = role.getName();
             if (name.startsWith(TOPIC_PREFIX)) {
-                topics.put(name.substring(8), new Topic(name.substring(8), role));
+                topics.put(name.substring(8), new Topic(name.substring(8), role, category));
             }
         }
     }
@@ -43,7 +54,7 @@ public class Server {
         guild.createRole()
                 .setName(TOPIC_PREFIX + topicName)
                 .setMentionable(true)
-                .queue(role -> topics.put(topicName, new Topic(topicName, role)));
+                .queue(role -> topics.put(topicName, new Topic(topicName, role, category)));
     }
 
     /**

--- a/src/main/java/entities/Topic.java
+++ b/src/main/java/entities/Topic.java
@@ -83,16 +83,14 @@ public class Topic {
         // get the lowest unused number
         int number = 1;
         for (int i = 1; i <= rooms.size() + 1; i++) {
-            // TODO: below code is dogshit
-            if (rooms.get(String.format("%s-%d", name, i)) == null) {
+            if (rooms.get(Room.makeName(name, i)) == null) {
                 number = i;
                 break;
             }
         }
 
         Room room = new Room(this, number, mentee);
-        // TODO: even more dogshit
-        rooms.put(String.format("%s-%d", name, number), room);
+        rooms.put(Room.makeName(name, number), room);
         return room;
     }
 

--- a/src/main/java/entities/Topic.java
+++ b/src/main/java/entities/Topic.java
@@ -80,7 +80,7 @@ public class Topic {
      * 
      * @return The new mentee
      */
-    public Member getNextFromQueue() {
+    public Member popFromQueue() {
         return queue.remove();
     }
 

--- a/src/main/java/entities/Topic.java
+++ b/src/main/java/entities/Topic.java
@@ -12,10 +12,31 @@ import java.util.Optional;
  * A topic for a server. Internally contains a queue of Members.
  */
 public class Topic {
+    /**
+     * This Topic's name
+     */
     private final String name;
+
+    /**
+     * The role associated with this Topic. Members with this Role are
+     * considered mentors for this topic and will have access to mentor-
+     * only commands and mentoring rooms.
+     */
     private final Role role;
+
+    /**
+     * The Category to place mentoring rooms into
+     */
     private final Category category;
+
+    /**
+     * List of members currently in queue
+     */
     private final LinkedList<Member> queue = new LinkedList<>();
+
+    /**
+     * Map from room names to Room objects
+     */
     private final HashMap<String, Room> rooms = new HashMap<>();
 
     /**
@@ -75,7 +96,6 @@ public class Topic {
 
     /**
      * Create a new mentoring room for this topic.
-     * @param mentor The mentor for this room
      * @param mentee The mentee for this room
      * @return The new Room
      */
@@ -94,14 +114,23 @@ public class Topic {
         return room;
     }
 
+    /**
+     * Delete a Room
+     * @param room The Room to delete
+     */
     public void deleteRoom(Room room) {
         room.delete();
         rooms.remove(room.getName());
     }
 
-    public Optional<Room> getRoom(String name) {
+    /**
+     * Geets the Room with the specified name
+     * @param roomName The name of the Room to retrieve
+     * @return The Room object, or null if the Room does not exist
+     */
+    public Optional<Room> getRoom(String roomName) {
         return rooms.values().stream()
-            .filter(r -> r.getName().toLowerCase().equals(name.toLowerCase()))
+            .filter(r -> r.getName().toLowerCase().equals(roomName.toLowerCase()))
             .findFirst();
     }
 

--- a/src/main/java/entities/Topic.java
+++ b/src/main/java/entities/Topic.java
@@ -92,17 +92,8 @@ public class Topic {
      * @return The new Room
      */
     public Room createRoom(Member mentee) {
-        // get the lowest unused number
-        int number = 1;
-        for (int i = 1; i <= rooms.size() + 1; i++) {
-            if (rooms.get(Room.makeName(name, i)) == null) {
-                number = i;
-                break;
-            }
-        }
-
-        Room room = new Room(this, number, mentee);
-        rooms.put(Room.makeName(name, number), room);
+        Room room = new Room(this, mentee);
+        rooms.put(room.getName(), room);
         return room;
     }
 

--- a/src/main/java/entities/Topic.java
+++ b/src/main/java/entities/Topic.java
@@ -25,6 +25,7 @@ public class Topic {
     /**
      * Constructs a new Topic object. This does not automatically create
      * the topic on the Discord server.
+     * 
      * @param name The name of the topic.
      * @param role The Role that represents this in the guild
      * @param category The Category that this topic's channels should be
@@ -38,6 +39,7 @@ public class Topic {
 
     /**
      * Add a Member to the back of the queue.
+     * 
      * @param member The Member to add
      */
     public void addToQueue(Member member) {
@@ -46,6 +48,7 @@ public class Topic {
 
     /**
      * Remove a Member from their position in the queue.
+     * 
      * @param member The Member to remove
      */
     public void removeFromQueue(Member member) {
@@ -54,7 +57,9 @@ public class Topic {
 
     /**
      * Check if a Member is inside the queue.
+     * 
      * @param member The Member to check
+     * 
      * @return True if the member is in the queue, false otherwise
      */
     public boolean isInQueue(Member member) {
@@ -63,6 +68,7 @@ public class Topic {
 
     /**
      * Returns an array of all Members in the queue.
+     * 
      * @return The Members in this queue
      */
     public Member[] getMembersInQueue() {
@@ -71,6 +77,7 @@ public class Topic {
 
     /**
      * Remove and return the next Member in the queue.
+     * 
      * @return The new mentee
      */
     public Member getNextFromQueue() {
@@ -79,7 +86,9 @@ public class Topic {
 
     /**
      * Create a new mentoring room for this topic.
+     * 
      * @param mentee The mentee for this room
+     * 
      * @return The new Room
      */
     public Room createRoom(Member mentee) {
@@ -99,6 +108,7 @@ public class Topic {
 
     /**
      * Delete a Room
+     * 
      * @param room The Room to delete
      */
     public void deleteRoom(Room room) {
@@ -108,7 +118,9 @@ public class Topic {
 
     /**
      * Geets the Room with the specified name
+     * 
      * @param roomName The name of the Room to retrieve
+     * 
      * @return The Room object, or null if the Room does not exist
      */
     public Optional<Room> getRoom(String roomName) {
@@ -119,16 +131,27 @@ public class Topic {
 
     /**
      * Get the name of this Topic.
+     * 
      * @return This Topic's name
      */
     public String getName() {
         return name;
     }
 
+    /**
+     * Get the role for this Topic.
+     * 
+     * @return This Topic's role
+     */
     public Role getRole() {
         return role;
     }
 
+    /**
+     * Get the category for this Topic.
+     * 
+     * @return This Topic's category
+     */
     public Category getCategory() {
         return category;
     }

--- a/src/main/java/entities/Topic.java
+++ b/src/main/java/entities/Topic.java
@@ -12,26 +12,9 @@ import java.util.Optional;
  * A topic for a server. Internally contains a queue of Members.
  */
 public class Topic {
-    /**
-     * This Topic's name
-     */
     private final String name;
-
-    /**
-     * The role associated with this Topic. Members with this Role are
-     * considered mentors for this topic and will have access to mentor-
-     * only commands and mentoring rooms.
-     */
     private final Role role;
-
-    /**
-     * The Category to place mentoring rooms into
-     */
     private final Category category;
-
-    /**
-     * List of members currently in queue
-     */
     private final LinkedList<Member> queue = new LinkedList<>();
 
     /**

--- a/src/main/java/entities/Topic.java
+++ b/src/main/java/entities/Topic.java
@@ -1,7 +1,9 @@
 package entities;
 
+import net.dv8tion.jda.api.entities.Category;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.Role;
+import net.dv8tion.jda.api.entities.TextChannel;
 
 import java.util.LinkedList;
 
@@ -11,17 +13,24 @@ import java.util.LinkedList;
 public class Topic {
     private final String name;
     private final Role role;
+    private final Category category;
     private final LinkedList<Member> queue = new LinkedList<>();
+
+    private Member mentee = null;
+    private TextChannel channel = null;
 
     /**
      * Constructs a new Topic object. This does not automatically create
      * the topic on the Discord server.
      * @param name The name of the topic.
      * @param role The Role that represents this in the guild
+     * @param category The Category that this topic's channels should be
+     *                 added to
      */
-    public Topic(String name, Role role) {
+    public Topic(String name, Role role, Category category) {
         this.name = name;
         this.role = role;
+        this.category = category;
     }
 
     /**
@@ -58,11 +67,35 @@ public class Topic {
     }
 
     /**
-     * Remove and return the next Member in the queue.
-     * @return The Member at the front of the queue
+     * Remove and return the next Member in the queue. This also
+     * automatically sets `mentee`.
+     * @return The new mentee
      */
     public Member getNextFromQueue() {
-        return queue.remove();
+        mentee = queue.remove();
+        return mentee;
+    }
+
+    /**
+     * Creates a new text channel for this Topic and adds the
+     * current mentee as an authorized user. If a channel already
+     * exists, it will be deleted.
+     */
+    public TextChannel setupChannel() {
+        deleteChannel();
+
+        channel = category.createTextChannel(name).complete();
+        channel.putPermissionOverride(mentee).complete();
+        return channel;
+    }
+
+    /**
+     * Deletes this topic's text channel, if it exists.
+     */
+    public void deleteChannel() {
+        if (channel != null) {
+            channel.delete().complete();
+        }
     }
 
     /**

--- a/src/main/java/entities/Topic.java
+++ b/src/main/java/entities/Topic.java
@@ -16,7 +16,7 @@ public class Topic {
     private final Role role;
     private final Category category;
     private final LinkedList<Member> queue = new LinkedList<>();
-    private final HashMap<Integer, Room> rooms = new HashMap<>();
+    private final HashMap<String, Room> rooms = new HashMap<>();
 
     /**
      * Constructs a new Topic object. This does not automatically create
@@ -82,25 +82,28 @@ public class Topic {
     public Room createRoom(Member mentee) {
         // get the lowest unused number
         int number = 1;
-        for (int i = 1; i <= rooms.size(); i++) {
-            if (rooms.get((Integer)i) == null) {
+        for (int i = 1; i <= rooms.size() + 1; i++) {
+            // TODO: below code is dogshit
+            if (rooms.get(String.format("%s-%d", name, i)) == null) {
                 number = i;
                 break;
             }
         }
 
         Room room = new Room(this, number, mentee);
-        rooms.put(number, room);
+        // TODO: even more dogshit
+        rooms.put(String.format("%s-%d", name, number), room);
         return room;
     }
 
     public void deleteRoom(Room room) {
-        rooms.remove(room.getNumber());
+        room.delete();
+        rooms.remove(room.getName());
     }
 
     public Optional<Room> getRoom(String name) {
         return rooms.values().stream()
-            .filter(r -> r.getName().equals(name))
+            .filter(r -> r.getName().toLowerCase().equals(name.toLowerCase()))
             .findFirst();
     }
 

--- a/src/main/java/launcher/Mentorbot.java
+++ b/src/main/java/launcher/Mentorbot.java
@@ -1,7 +1,6 @@
 package launcher;
 
 import listeners.MainEventListener;
-import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.JDABuilder;
 import net.dv8tion.jda.api.requests.GatewayIntent;
 import net.dv8tion.jda.api.utils.ChunkingFilter;
@@ -9,14 +8,13 @@ import net.dv8tion.jda.api.utils.ChunkingFilter;
 import javax.security.auth.login.LoginException;
 
 public class Mentorbot {
-    @SuppressWarnings("unused")
     public static void main(String[] args) {
         try {
-            JDA jda = JDABuilder.createDefault(System.getenv("MENTORBOT_TOKEN"))
-                    .setChunkingFilter(ChunkingFilter.ALL)
-                    .enableIntents(GatewayIntent.GUILD_MESSAGES)
-                    .addEventListeners(new MainEventListener())
-                    .build();
+            JDABuilder.createDefault(System.getenv("MENTORBOT_TOKEN"))
+                .setChunkingFilter(ChunkingFilter.ALL)
+                .enableIntents(GatewayIntent.GUILD_MESSAGES)
+                .addEventListeners(new MainEventListener())
+                .build();
         } catch (LoginException ex) {
             ex.printStackTrace();
         }

--- a/src/main/java/launcher/Mentorbot.java
+++ b/src/main/java/launcher/Mentorbot.java
@@ -9,6 +9,7 @@ import net.dv8tion.jda.api.utils.ChunkingFilter;
 import javax.security.auth.login.LoginException;
 
 public class Mentorbot {
+    @SuppressWarnings("unused")
     public static void main(String[] args) {
         try {
             JDA jda = JDABuilder.createDefault(System.getenv("MENTORBOT_TOKEN"))

--- a/src/main/java/listeners/MainEventListener.java
+++ b/src/main/java/listeners/MainEventListener.java
@@ -2,6 +2,7 @@ package listeners;
 
 import entities.Server;
 import entities.Topic;
+import entities.Topic.Channels;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.Permission;
 import net.dv8tion.jda.api.entities.Activity;
@@ -221,12 +222,13 @@ public class MainEventListener extends ListenerAdapter {
         }
 
         Member mentee = topic.getNextFromQueue();
-        TextChannel newChannel = topic.setupChannel();
+        Channels newChannels = topic.setupChannels();
         channel.sendMessage(String.format(
-                "%s is ready for %s in %s.",
-                member.getAsMention(),
-                mentee.getAsMention(),
-                newChannel.getAsMention())).queue();
+            "%s is ready for %s.\n\nText channel: %s\nVoice channel: %s",
+            member.getAsMention(),
+            mentee.getAsMention(),
+            newChannels.getTextChannel().getAsMention(),
+            newChannels.getVoiceChannelInvite().getUrl())).queue();
     }
 
     private void showQueue(Member member, TextChannel channel, Server server, String[] args) {

--- a/src/main/java/listeners/MainEventListener.java
+++ b/src/main/java/listeners/MainEventListener.java
@@ -23,6 +23,7 @@ public class MainEventListener extends ListenerAdapter {
     private interface CommandHandler {
         /**
          * Handle a single command.
+         * 
          * @param member The member that called the command
          * @param channel The channel that the command was called in
          * @param server The Server that the command was called in
@@ -38,7 +39,9 @@ public class MainEventListener extends ListenerAdapter {
 
     /**
      * Check if the given Member has administrator permissions.
+     * 
      * @param member The Member to check
+     * 
      * @return True if the Member has admin, false otherwise
      */
     private static boolean isAdmin(Member member) {
@@ -47,8 +50,10 @@ public class MainEventListener extends ListenerAdapter {
 
     /**
      * Check if the given Member is a mentor for a topic.
+     * 
      * @param member The Member to check
      * @param topic The Topic to check
+     * 
      * @return True if the Member has permission, false otherwise
      */
     private static boolean isMentor(Member member, Topic topic) {
@@ -59,7 +64,9 @@ public class MainEventListener extends ListenerAdapter {
 
     /**
      * Check if the given Member is a mentor for any topic.
+     * 
      * @param member The Member to check
+     * 
      * @return True if the Member is a mentor, false otherwise
      */
     private static boolean isMentor(Member member) {
@@ -70,10 +77,12 @@ public class MainEventListener extends ListenerAdapter {
 
     /**
      * Check if the given Topic exists in the Server. Notifies the user if the topic does not exist.
+     * 
      * @param member The Member to reply to
      * @param channel The Channel to reply within
      * @param server The Server to check in
      * @param topicName The Topic to check for
+     * 
      * @return Contains the Topic, if it exists
      */
     private static Optional<Topic> checkTopicExists(Member member, TextChannel channel, Server server, String topicName) {

--- a/src/main/java/listeners/MainEventListener.java
+++ b/src/main/java/listeners/MainEventListener.java
@@ -221,10 +221,12 @@ public class MainEventListener extends ListenerAdapter {
         }
 
         Member mentee = topic.getNextFromQueue();
+        TextChannel newChannel = topic.setupChannel();
         channel.sendMessage(String.format(
-                "%s is ready for %s.",
+                "%s is ready for %s in %s.",
                 member.getAsMention(),
-                mentee.getAsMention())).queue();
+                mentee.getAsMention(),
+                newChannel.getAsMention())).queue();
     }
 
     private void showQueue(Member member, TextChannel channel, Server server, String[] args) {

--- a/src/main/java/listeners/MainEventListener.java
+++ b/src/main/java/listeners/MainEventListener.java
@@ -1,8 +1,8 @@
 package listeners;
 
+import entities.Room;
 import entities.Server;
 import entities.Topic;
-import entities.Topic.Channels;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.Permission;
 import net.dv8tion.jda.api.entities.Activity;
@@ -224,13 +224,13 @@ public class MainEventListener extends ListenerAdapter {
         }
 
         Member mentee = topic.getNextFromQueue();
-        Channels newChannels = topic.setupChannels();
+        Room room = topic.createRoom(mentee);
         channel.sendMessage(String.format(
             "%s is ready for %s.\n\nText channel: %s\nVoice channel: %s",
             member.getAsMention(),
             mentee.getAsMention(),
-            newChannels.getTextChannel().getAsMention(),
-            newChannels.getVoiceChannelInvite().getUrl())).queue();
+            room.getTextChannel().getAsMention(),
+            room.getVoiceChannelInvite().getUrl())).queue();
     }
 
     private void showQueue(Member member, TextChannel channel, Server server, String[] args) {
@@ -282,7 +282,7 @@ public class MainEventListener extends ListenerAdapter {
     }
 
     private void finish(Member member, TextChannel channel, Server server, String[] args) {
-        // only run inside a topic's text channel
+        // only run inside a room
         Optional<Topic> optionalTopic = server.getTopic(channel.getName());
         if (optionalTopic.isEmpty()) {
             channel.sendMessage(String.format(
@@ -297,8 +297,6 @@ public class MainEventListener extends ListenerAdapter {
             channel.sendMessage(member.getAsMention() + " You do not have permission to run this command.").queue();
             return;
         }
-
-        topic.deleteChannels();
     }
 
     private void unknownCommand(Member member, TextChannel channel, Server server, String[] args) {

--- a/src/main/java/listeners/MainEventListener.java
+++ b/src/main/java/listeners/MainEventListener.java
@@ -235,7 +235,7 @@ public class MainEventListener extends ListenerAdapter {
             return;
         }
 
-        Member mentee = topic.getNextFromQueue();
+        Member mentee = topic.popFromQueue();
         Room room = topic.createRoom(mentee);
         channel.sendMessage(String.format(
             "%s is ready for %s.\n\nText channel: %s\nVoice channel: %s",

--- a/src/main/java/listeners/MainEventListener.java
+++ b/src/main/java/listeners/MainEventListener.java
@@ -282,9 +282,20 @@ public class MainEventListener extends ListenerAdapter {
     }
 
     private void finish(Member member, TextChannel channel, Server server, String[] args) {
+        Topic topic = null;
+        Room room = null;
+        
+        // find the topic corresponding to this channel
+        for (Topic t : server.getTopics()) {
+            Optional<Room> optionalRoom = t.getRoom(channel.getName());
+            if (optionalRoom.isPresent()) {
+                topic = t;
+                room = optionalRoom.get();
+            }
+        }
+
         // only run inside a room
-        Optional<Topic> optionalTopic = server.getTopic(channel.getName());
-        if (optionalTopic.isEmpty()) {
+        if (room == null) {
             channel.sendMessage(String.format(
                 "%s This command must be run inside a topic's text channel.",
                 member.getAsMention())).queue();
@@ -292,11 +303,12 @@ public class MainEventListener extends ListenerAdapter {
         }
 
         // do not run if caller does not have mentor role for this topic or admin privileges
-        Topic topic = optionalTopic.get();
         if (!isMentor(member, topic) && !isAdmin(member)) {
             channel.sendMessage(member.getAsMention() + " You do not have permission to run this command.").queue();
             return;
         }
+
+        topic.deleteRoom(room);
     }
 
     private void unknownCommand(Member member, TextChannel channel, Server server, String[] args) {

--- a/src/main/java/listeners/MainEventListener.java
+++ b/src/main/java/listeners/MainEventListener.java
@@ -23,7 +23,7 @@ public class MainEventListener extends ListenerAdapter {
     private interface CommandHandler {
         /**
          * Handle a single command.
-         * 
+         *
          * @param member The member that called the command
          * @param channel The channel that the command was called in
          * @param server The Server that the command was called in
@@ -39,9 +39,9 @@ public class MainEventListener extends ListenerAdapter {
 
     /**
      * Check if the given Member has administrator permissions.
-     * 
+     *
      * @param member The Member to check
-     * 
+     *
      * @return True if the Member has admin, false otherwise
      */
     private static boolean isAdmin(Member member) {
@@ -50,10 +50,10 @@ public class MainEventListener extends ListenerAdapter {
 
     /**
      * Check if the given Member is a mentor for a topic.
-     * 
+     *
      * @param member The Member to check
      * @param topic The Topic to check
-     * 
+     *
      * @return True if the Member has permission, false otherwise
      */
     private static boolean isMentor(Member member, Topic topic) {
@@ -64,9 +64,9 @@ public class MainEventListener extends ListenerAdapter {
 
     /**
      * Check if the given Member is a mentor for any topic.
-     * 
+     *
      * @param member The Member to check
-     * 
+     *
      * @return True if the Member is a mentor, false otherwise
      */
     private static boolean isMentor(Member member) {
@@ -77,12 +77,12 @@ public class MainEventListener extends ListenerAdapter {
 
     /**
      * Check if the given Topic exists in the Server. Notifies the user if the topic does not exist.
-     * 
+     *
      * @param member The Member to reply to
      * @param channel The Channel to reply within
      * @param server The Server to check in
      * @param topicName The Topic to check for
-     * 
+     *
      * @return Contains the Topic, if it exists
      */
     private static Optional<Topic> checkTopicExists(Member member, TextChannel channel, Server server, String topicName) {
@@ -295,19 +295,19 @@ public class MainEventListener extends ListenerAdapter {
 
     private void finish(Member member, TextChannel channel, Server server, String[] args) {
         Topic topic = null;
-        Room room = null;
-        
+        Optional<Room> optionalRoom = Optional.empty();
+
         // find the topic corresponding to this channel
         for (Topic t : server.getTopics()) {
-            Optional<Room> optionalRoom = t.getRoom(channel.getName());
+            optionalRoom = t.getRoom(channel.getName());
             if (optionalRoom.isPresent()) {
                 topic = t;
-                room = optionalRoom.get();
+                break;
             }
         }
 
         // only run inside a room
-        if (room == null) {
+        if (optionalRoom.isEmpty()) {
             channel.sendMessage(String.format(
                 "%s This command must be run inside a topic's text channel.",
                 member.getAsMention())).queue();
@@ -320,7 +320,7 @@ public class MainEventListener extends ListenerAdapter {
             return;
         }
 
-        topic.deleteRoom(room);
+        topic.deleteRoom(optionalRoom.get());
     }
 
     private void unknownCommand(Member member, TextChannel channel, Server server, String[] args) {

--- a/src/main/java/listeners/MainEventListener.java
+++ b/src/main/java/listeners/MainEventListener.java
@@ -31,6 +31,9 @@ public class MainEventListener extends ListenerAdapter {
         void handle(@NotNull Member member, TextChannel channel, Server server, String[] args);
     }
 
+    /**
+     * Map from a server name to a Server object.
+     */
     private final HashMap<String, Server> servers = new HashMap<>();
 
     /**


### PR DESCRIPTION
Current user flow:
1) User runs `$queue <topic>`
2) Mentor runs `$ready <topic>`
3) Bot automatically creates a text channel and voice channel with name `<topic>-<room number>` in the `Mentoring` category
    a) `@everyone` is blocked from seeing the channel, except for the mentee, the role for that topic, and the bot itself
    b) The lowest unused room number is used
4) Bot notifies mentor/mentee
![image](https://user-images.githubusercontent.com/16471311/107243282-d9198180-69fa-11eb-9d92-e432fe7ba392.png)
    a) We're using an invite here for the voice channel, since you can't mention a voice channel. It can only be used by those with permission to access the mentoring channel.
    b) The invite has two max uses, and expires after 5 minutes. This ensures that we don't run out of invites, since there is an (unknown) cap on how many active invites a server can have.
5) Mentor runs `$finish` **inside the room's text channel** to end the interaction
    a) This deletes the text/voice channels and allows that room number to be reused.

Closes #6 