### PR TITLE
Made .jar name consistent

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: java -jar build/libs/mentorbot-1.0-SNAPSHOT-all.jar
+web: java -jar build/libs/mentorbot.jar

--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,10 @@ jar {
     }
 }
 
+shadowJar {
+    archiveFileName = "mentorbot.${extension}"
+}
+
 dependencies {
     testImplementation group: 'junit', name: 'junit', version: '4.12'
     implementation 'net.dv8tion:JDA:4.2.0_198'


### PR DESCRIPTION
Heroku makes the .jar file name weird, but this should make it consistent between local and server builds